### PR TITLE
merging fov-test back into pre-pilot-changes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,5 +56,5 @@
         "temp/": true,
         "Temp/": true
     },
-    "dotnet.defaultSolution": "Octagon.sln"
+    "dotnet.defaultSolution": "octagon.sln"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,5 +56,5 @@
         "temp/": true,
         "Temp/": true
     },
-    "dotnet.defaultSolution": "octagon.sln"
+    "dotnet.defaultSolution": "Octagon.sln"
 }

--- a/Assets/AmplifyShaderEditor/Examples/Built-In Samples.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Examples/Built-In Samples.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: e00e6f90ab8233e46a41c5e33917c642
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Examples/HDRP Samples 10x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Examples/HDRP Samples 10x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 9da5530d5ebfab24c8ecad68795e720f
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Examples/HDRP Samples 12x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Examples/HDRP Samples 12x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: aa102d640b98b5d4781710a3a3dd6983
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Examples/HDRP Samples 14x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Examples/HDRP Samples 14x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 7a0bb33169d95ec499136d59cb25918b
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Examples/HDRP Samples 15x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Examples/HDRP Samples 15x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 641c955d37d2fac4f87e00ac5c9d9bd8
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Examples/HDRP Samples 16x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Examples/HDRP Samples 16x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 2690f45490c175045bbdc63395bf6278
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Examples/HDRP Samples 17x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Examples/HDRP Samples 17x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: f42c2bc4dab4723429b0d30b635c3035
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Examples/HDRP Samples.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Examples/HDRP Samples.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: d1c0b77896049554fa4b635531caf741
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Examples/Sample Resources.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Examples/Sample Resources.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: c0a0a980c9ba86345bc15411db88d34f
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Examples/URP Samples 10x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Examples/URP Samples 10x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 2edbf4a9b9544774bbef617e92429664
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Examples/URP Samples 12x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Examples/URP Samples 12x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 13ab599a7bda4e54fba3e92a13c9580a
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Examples/URP Samples 14x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Examples/URP Samples 14x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: f6f268949ccf3f34fa4d18e92501ed82
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Examples/URP Samples 15x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Examples/URP Samples 15x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 69bc3229216b1504ea3e28b5820bbb0d
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Examples/URP Samples 16x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Examples/URP Samples 16x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 4f665a06c5a2aa5499fa1c79ac058999
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Examples/URP Samples 17x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Examples/URP Samples 17x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 47fc5ccecd261894994c1e9e827cf553
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Examples/URP Samples.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Examples/URP Samples.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: a9d68dd8913f05d4d9ce75e7b40c6044
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/HDRP 10x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/HDRP 10x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 2243c8b4e1ab6914995699133f67ab5a
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/HDRP 12x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/HDRP 12x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 9a5e61a8b3421b944863d0946e32da0a
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/HDRP 14x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/HDRP 14x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 89f0b84148d149d4d96b838d7ef60e92
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/HDRP 15x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/HDRP 15x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 19939ee2cdb76e0489b1b8cd4bed7f3d
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/HDRP 16x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/HDRP 16x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 70777e8ce9f3c8d4a8182ca2f965cdb2
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/HDRP 17x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/HDRP 17x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: daf511a6dae20e641a9d69d025f023e4
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/URP 10x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/URP 10x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: b460b52e6c1feae45b70b7ddc2c45bd6
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/URP 12x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/URP 12x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 57fcea0ed8b5eb347923c4c21fa31b57
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/URP 14x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/URP 14x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 2e9da72e7e3196146bf7d27450013734
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/URP 15x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/URP 15x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 0904cdf24ddcd5042b024326476220d5
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/URP 16x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/URP 16x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 929783250050f8a448821b6ca1f2c578
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/URP 17x.unitypackage.meta
+++ b/Assets/AmplifyShaderEditor/Plugins/EditorResources/Templates/URP 17x.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 89da50d95d149b744bf10bd27babcf79
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Graphy - Ultimate Stats Monitor/Graphy_CustomizationScene.unitypackage.meta
+++ b/Assets/Graphy - Ultimate Stats Monitor/Graphy_CustomizationScene.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 9df6cd2f9439dd04fb0d7a5aeb12e189
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/ReportHorizontalFoV.cs
+++ b/Assets/ReportHorizontalFoV.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ReportHorizontalFoV : MonoBehaviour
+{
+    public Camera playerCamera;
+
+
+public void Start()
+{
+    playerCamera = gameObject.GetComponent<Camera>();
+}
+
+public void Update()
+{
+    CalculateEffectiveFoVs();
+}
+
+public void CalculateEffectiveFoVs()
+{
+    float verticalFoV = playerCamera.fieldOfView;
+    float aspectRatio = playerCamera.aspect;
+    float horizontalFoV = 2 * Mathf.Atan(Mathf.Tan(verticalFoV * Mathf.Deg2Rad / 2) * aspectRatio) * Mathf.Rad2Deg;
+
+    Debug.Log("Vertical FoV: " + verticalFoV + ", Horizontal FoV: " + horizontalFoV + ", aspect ratio: " + aspectRatio);
+}
+}

--- a/Assets/ReportHorizontalFoV.cs.meta
+++ b/Assets/ReportHorizontalFoV.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5eaeec672c1da3f43941017687fcd25c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/PlayerCamera.prefab
+++ b/Assets/Resources/PlayerCamera.prefab
@@ -13,6 +13,8 @@ GameObject:
   - component: {fileID: 7285429163594190396}
   - component: {fileID: 407985838471721892}
   - component: {fileID: 6774969042331722791}
+  - component: {fileID: -3198529440930816959}
+  - component: {fileID: 486424479694939262}
   m_Layer: 0
   m_Name: PlayerCamera
   m_TagString: MainCamera
@@ -129,3 +131,30 @@ MonoBehaviour:
   playerBody: {fileID: 0}
   networkManager: {fileID: 0}
   unlockMouseTrigger: 0
+--- !u!114 &-3198529440930816959
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6136897480289246582}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8afafaae642171d47bf3383a1c6a03f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerCamera: {fileID: 0}
+  wall8Centre: {x: 0, y: 0, z: 0}
+--- !u!114 &486424479694939262
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6136897480289246582}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5eaeec672c1da3f43941017687fcd25c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerCamera: {fileID: 0}

--- a/Assets/Resources/PlayerCamera.prefab
+++ b/Assets/Resources/PlayerCamera.prefab
@@ -108,7 +108,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 981360803
+  GlobalObjectIdHash: 4183896318
   AlwaysReplicateAsRoot: 0
   SynchronizeTransform: 1
   ActiveSceneSynchronization: 0
@@ -156,3 +156,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a16c47aba9c0af04cb1199885ae2fbcb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playerCamera: {fileID: 0}

--- a/Assets/Resources/PlayerCamera.prefab
+++ b/Assets/Resources/PlayerCamera.prefab
@@ -13,8 +13,8 @@ GameObject:
   - component: {fileID: 7285429163594190396}
   - component: {fileID: 407985838471721892}
   - component: {fileID: 6774969042331722791}
-  - component: {fileID: -3198529440930816959}
   - component: {fileID: 486424479694939262}
+  - component: {fileID: 1395623634295999046}
   m_Layer: 0
   m_Name: PlayerCamera
   m_TagString: MainCamera
@@ -131,20 +131,6 @@ MonoBehaviour:
   playerBody: {fileID: 0}
   networkManager: {fileID: 0}
   unlockMouseTrigger: 0
---- !u!114 &-3198529440930816959
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6136897480289246582}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8afafaae642171d47bf3383a1c6a03f6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  playerCamera: {fileID: 0}
-  wall8Centre: {x: 0, y: 0, z: 0}
 --- !u!114 &486424479694939262
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -158,3 +144,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playerCamera: {fileID: 0}
+--- !u!114 &1395623634295999046
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6136897480289246582}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a16c47aba9c0af04cb1199885ae2fbcb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scenes/OctagonStage.unity
+++ b/Assets/Scenes/OctagonStage.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.4366765, g: 0.48427117, b: 0.56452465, a: 1}
+  m_IndirectSpecularColor: {r: 0.4366757, g: 0.48427194, b: 0.5645252, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -933,7 +933,7 @@ Transform:
   m_GameObject: {fileID: 102011759}
   serializedVersion: 2
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 40.2, z: 0}
+  m_LocalPosition: {x: 0, y: 45.32, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -5830,7 +5830,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4845276930943762971, guid: 2da3dcc22749e7f4280737786d898334, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0.000076293945
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4845637959249703711, guid: 2da3dcc22749e7f4280737786d898334, type: 3}
       propertyPath: m_AnchorMax.y

--- a/Assets/Scripts/TrialLogic/GameManager.cs
+++ b/Assets/Scripts/TrialLogic/GameManager.cs
@@ -691,19 +691,19 @@ public class GameManager : SingletonNetwork<GameManager>
         int anchorWallIndex = Random.Range(0, walls.Count);
         // Debug.Log($"anchor walls is {anchorWallIndex}");
 
-        // Replaced with a weighted list to bias towards wallSep=1 trials
+        // Replaced the below with a weighted list to bias towards wallSep=1 trials
         // // Randomly choose a wall separation value for this trial
         // int i = General.wallSeparations[Random.Range(0, General.wallSeparations.Count)];
 
 
         // Create weighted list of wall separation values to draw from 
-        WeightedList<string> wallSeparationsWeighted = new();
+        WeightedList<int> wallSeparationsWeighted = new();
         for (int i = 0; i < General.wallSeparations.Count; i++)
         {
             wallSeparationsWeighted.Add(General.wallSeparations[i], General.wallSeparationsProbabilities[i]);
         }
         // Query the weighted list for this trial's wall separation
-        wallSeparation = wallSeparationsWeighted.Next();
+        int wallSeparation = wallSeparationsWeighted.Next();
         
 
         // choose a random second wall that is consistent with anchor wall for this trial type

--- a/Assets/Scripts/TrialLogic/TrialHandler.cs
+++ b/Assets/Scripts/TrialLogic/TrialHandler.cs
@@ -154,6 +154,7 @@ public class TrialHandler : NetworkBehaviour
 
         // Save the current colour of the wall before overwriting it 
         // This should be the first material, the wall face
+        // (May be cleaner to specify this variable in a higher scope. But works fine atm)
         defaultWallColour = wall1.GetComponent<Renderer>().materials[0].color;
         Debug.Log($"Default wall colour is saved as {defaultWallColour}");
         Debug.Log($"ColourWalls() uses {wallID1} and {wallID2} as wall values");

--- a/Assets/Scripts/Utility/GeneralGlobals.cs
+++ b/Assets/Scripts/Utility/GeneralGlobals.cs
@@ -25,8 +25,8 @@ namespace Globals
                                                                           // random choice within list
 
         public static List<int> wallSeparationsProbabilities = new List<int>{50,25,25};
-        public static Color wallHighColour = Color.red;
-        public static Color wallLowColour = Color.blue;
+        public static Color wallHighColour = Color.blue; // Color.red
+        public static Color wallLowColour = Color.red;  // Color.blue
         public static Color wallInteractionZoneColour = new Color(1, 215/255f, 0, 129/255f);
         public static bool automaticStartTrial = false;
 

--- a/Assets/Scripts/Utility/GeneralGlobals.cs
+++ b/Assets/Scripts/Utility/GeneralGlobals.cs
@@ -23,6 +23,8 @@ namespace Globals
         public static List<int> trialTypeProbabilities = new List<int>{80, 10, 10};
         public static List<int> wallSeparations = new List<int>{1,2,4};   // index difference between trial walls
                                                                           // random choice within list
+
+        public static List<int> wallSeparationsProbabilities = new List<int>{50,25,25};
         public static Color wallHighColour = Color.red;
         public static Color wallLowColour = Color.blue;
         public static Color wallInteractionZoneColour = new Color(1, 215/255f, 0, 129/255f);

--- a/Assets/SetFoV.cs
+++ b/Assets/SetFoV.cs
@@ -11,10 +11,16 @@ public class SetFoV : MonoBehaviour
         playerCamera = gameObject.GetComponent<Camera>();
 
         // Set (default) vertical FoV to the correct value for an aspect ratio
-        // of 1.713521 to give a horizontal FoV of 90.
+        // of 1.713521 to givei intended horizontal FoV.
         // This is currently hard coded based on the aspect ratio given by the 
         // fullscreen-windowed game on the Octagon laptops
-        playerCamera.fieldOfView = 60.53513f;
+
+        /* // horizontal FoV: 90
+        playerCamera.fieldOfView = 60.53513f; */
+
+        // horizontal FoV: 110
+        playerCamera.fieldOfView = 79.61958f;
+
     }
 
 }

--- a/Assets/SetFoV.cs
+++ b/Assets/SetFoV.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SetFoV : MonoBehaviour
+{
+    public Camera playerCamera;
+    // Start is called before the first frame update
+    void Start()
+    {
+        playerCamera = gameObject.GetComponent<Camera>();
+
+        // Set (default) vertical FoV to the correct value for an aspect ratio
+        // of 1.713521 to give a horizontal FoV of 90.
+        // This is currently hard coded based on the aspect ratio given by the 
+        // fullscreen-windowed game on the Octagon laptops
+        playerCamera.fieldOfView = 60.53513f;
+    }
+
+}

--- a/Assets/SetFoV.cs.meta
+++ b/Assets/SetFoV.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a16c47aba9c0af04cb1199885ae2fbcb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/TestCoordinateInView.cs
+++ b/Assets/TestCoordinateInView.cs
@@ -1,0 +1,39 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TestCoordinateInView : MonoBehaviour
+{
+public Camera playerCamera;
+public Vector3 wall8Centre;
+
+public void Start()
+{
+    playerCamera = gameObject.GetComponent<Camera>();
+
+    wall8Centre = new Vector3(-14.1000004f,3.69000006f,14.1499996f);
+
+}
+
+public void Update()
+{
+    bool isInHorizontalBounds = IsInView(wall8Centre);
+    Debug.Log(isInHorizontalBounds);
+}
+
+// Method to return a bool that identifies whether a coordinate in the scene is currently in the camera view
+// If the viewportPos value for any given axis lies within [0,1], the object is in view in this axis
+public bool IsInView(Vector3 objectPosition)
+{
+    // Convert the object position to viewport space
+    Vector3 viewportPos = playerCamera.WorldToViewportPoint(objectPosition);
+
+    // Check if the object is within the viewport bounds
+    bool isInHorizontalBounds = viewportPos.x >= 0 && viewportPos.x <= 1;
+    bool isInVerticalBounds = viewportPos.y >= 0 && viewportPos.y <= 1;
+    bool isInFrontOfCamera = viewportPos.z > 0;
+
+    return isInHorizontalBounds && isInVerticalBounds && isInFrontOfCamera;
+    // return viewportPos.z;
+}
+}

--- a/Assets/TestCoordinateInView.cs.meta
+++ b/Assets/TestCoordinateInView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8afafaae642171d47bf3383a1c6a03f6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fov-test gives 2 new scripts attached to the PlayerCamera prefab in Resources. One reports the current hori and vert FoVs and aspect ratios at Update, the other sets the FoVs in a hard-coded way at Start. 
High and Low wall colours have been switched in Globals. Game should now be ready to continue pilot experiments